### PR TITLE
Fix purchases above 999 points when free buy is enabled

### DIFF
--- a/Packer-SupplyRaid/src/Plugin/src/Scripts/SR_Manager.cs
+++ b/Packer-SupplyRaid/src/Plugin/src/Scripts/SR_Manager.cs
@@ -1973,6 +1973,9 @@ namespace SupplyRaid
             if (instance == null)
                 return false;
 
+            if (instance.optionFreeBuyMenu)
+                return true;
+
             if (instance.Points >= amount)
                 return true;
             else


### PR DESCRIPTION
When purchasing something from the buy menu that is above 999 points, `SR_Manager.EnoughPoints` returns false even when free buy is turned on.

This PR just throws in a free-buy check in EnoughPoints to fix this